### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@ This tool takes as input a plain text list such as the one exported by the offic
 
 A GUI will be implemented soon, with an associated release as a Windows `.exe` binary.
 
+## Installation
+
+To setup the project the first time:
+
+```shell
+# Create a new sandbox
+python3 -m venv .venv
+# Activate the sandbox
+source .venv/bin/activate
+# Install dependencies
+pip install -r requirements.txt
+
+# Install system dependency
+sudo apt install python3-tk
+```
+
+Then the next times:
+
+```shell
+# Activate the sandbox
+source .venv/bin/activate
+```
+
 ## Author
 
 Thomas BAGREL <tomsb07@gmail.com>

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import click
 import re
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+click==8.1.7
+Pillow==10.0.0
+pypdf==3.15.2
+PyYAML==6.0.1
+reportlab==4.0.4


### PR DESCRIPTION
Fixes #1 

## What this PR does

This PR adds simple installation instructions, for using a sandbox populated by `pip`

## How to trust this PR

1. Execute the instructions given in the README.md and run `./main.py --help`
2. Observe that there is no failure on missing import